### PR TITLE
Add course groups as cluster-scope resources

### DIFF
--- a/cluster-scope/base/user.openshift.io/groups/cs210/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/cs210/group.yaml
@@ -1,0 +1,5 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: cs210
+users: []

--- a/cluster-scope/base/user.openshift.io/groups/cs210/kustomization.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/cs210/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - group.yaml

--- a/cluster-scope/base/user.openshift.io/groups/cs506/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/cs506/group.yaml
@@ -1,0 +1,5 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: cs506
+users: []

--- a/cluster-scope/base/user.openshift.io/groups/cs506/kustomization.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/cs506/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - group.yaml

--- a/cluster-scope/base/user.openshift.io/groups/ee440/group.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/ee440/group.yaml
@@ -1,0 +1,5 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: ee440
+users: []

--- a/cluster-scope/base/user.openshift.io/groups/ee440/kustomization.yaml
+++ b/cluster-scope/base/user.openshift.io/groups/ee440/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+    - group.yaml


### PR DESCRIPTION
This is in responese to: https://github.com/OCP-on-NERC/nerc-ocp-config/pull/352

Adding the groups as cluster scope resources to keep consistency with nerc-ocp-config