### PR TITLE
Add pod access to the cronjob

### DIFF
--- a/cronjobs/nb-culler/clusterrole.yaml
+++ b/cronjobs/nb-culler/clusterrole.yaml
@@ -30,3 +30,11 @@ rules:
   - list
   - watch
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
The nb-culler cronjob needs pods access to check GPU resources.  