### PR TITLE
Update nb-culler policy for 2024 fall semester

### DIFF
--- a/cronjobs/nb-culler/cronjob.yaml
+++ b/cronjobs/nb-culler/cronjob.yaml
@@ -51,60 +51,83 @@ spec:
                       difference=$((current_time - timestamp))
                       user_in_group1=false
                       user_in_group2=false
+                      pvc="jupyterhub-nb-${nb#"jupyter-nb-"}-pvc"
 
                       if [[ " $group_members_1 " =~ " $user " ]]; then
                           echo "$user is in the $GROUP_NAME_1 group."
                           user_in_group1=true
-                          cutoff_time=$CUTOFF_TIME_1
-                      elif [[ " $group_members_2 " =~ " $user " ]]; then
+                      fi
+                      if [[ " $group_members_2 " =~ " $user " ]]; then
                           echo "$user is in the $GROUP_NAME_2 group."
                           user_in_group2=true
-                          cutoff_time=$CUTOFF_TIME_2
                       fi
 
-                      if $user_in_group1 || $user_in_group2; then
-                          pod_name=$(oc get pods -n $ns -l notebook-name=$nb -o jsonpath="{.items[0].metadata.name}")
-                          gpu_request=$(oc get pod $pod_name -n $ns -o jsonpath='{.spec.containers[].resources.requests.nvidia\.com/gpu}')
-                          if [[ ! -z $gpu_request ]]; then
-                              echo "$nb is requesting GPU resources, deleting the notebook"
+                      if $user_in_group1 && $user_in_group2; then
+                          # Handle both group conditions
+                          if [[ $image != *$IMAGE_NAME_1* && $image != *$IMAGE_NAME_2* && $image != *$IMAGE_NAME_3* ]]; then
+                              echo "$nb is not using the correct images, deleting the notebook"
                               oc delete notebook $nb -n $ns
-                              oc delete pvc $nb -n $ns
-                          elif [[ $image != *$IMAGE_NAME* ]]; then
-                              echo "$nb is not using $IMAGE_NAME image, deleting the notebook"
+                              oc delete pvc $pvc -n $ns
+                          elif [[ $image == *$IMAGE_NAME_1* && $size != "X Small" ]]; then
+                              echo "$nb resource size is not correct for $IMAGE_NAME_1, deleting the notebook"
                               oc delete notebook $nb -n $ns
-                              oc delete pvc $nb -n $ns
-                          elif [[ $size != "X Small" ]]; then
-                              echo "$nb resource size is not correct, deleting the notebook"
+                              oc delete pvc $pvc -n $ns
+                          elif [[ ($image == *$IMAGE_NAME_2* || $image == *$IMAGE_NAME_3*) && $size != "Small" ]]; then
+                              echo "$nb resource size is not correct for $IMAGE_NAME_2 or $IMAGE_NAME_3, deleting the notebook"
                               oc delete notebook $nb -n $ns
-                              oc delete pvc $nb -n $ns
-                          elif [ $difference -gt $cutoff_time ]; then
-                              echo "$nb is more than $(($cutoff_time / 3600)) hours old, stopping the notebook"
+                              oc delete pvc $pvc -n $ns
+                          elif [[ $image == *$IMAGE_NAME_1* && $difference -gt $CUTOFF_TIME_1 ]]; then
+                              echo "$nb is more than $(($CUTOFF_TIME_1 / 3600)) hours old, stopping the notebook"
+                              oc patch notebook $nb -n $ns --type merge -p '{"metadata":{"annotations":{"kubeflow-resource-stopped":"'$(date -u +"%Y-%m-%dT%H:%M:%SZ")'"}}}'
+                          elif [[ $image == *$IMAGE_NAME_2* || $image == *$IMAGE_NAME_3* ]]; then
+                              echo "$nb is using $IMAGE_NAME_2 or $IMAGE_NAME_3, no shutdown applied."
+                          fi
+                      elif $user_in_group1; then
+                          # Handle group1 conditions
+                          if [[ $image != *$IMAGE_NAME_1* || $size != "X Small" ]]; then
+                              echo "$nb is not using the correct image or size, deleting the notebook"
+                              oc delete notebook $nb -n $ns
+                              oc delete pvc $pvc -n $ns
+                          elif [ $difference -gt $CUTOFF_TIME_1 ]; then
+                              echo "$nb is more than $(($CUTOFF_TIME_1 / 3600)) hours old, stopping the notebook"
                               oc patch notebook $nb -n $ns --type merge -p '{"metadata":{"annotations":{"kubeflow-resource-stopped":"'$(date -u +"%Y-%m-%dT%H:%M:%SZ")'"}}}'
                           fi
+                      elif $user_in_group2; then
+                          # Handle group2 conditions
+                          if [[ ($image != *$IMAGE_NAME_2* && $image != *$IMAGE_NAME_3*) || $size != "Small" ]]; then
+                              echo "$nb is not using the correct image or size, deleting the notebook"
+                              oc delete notebook $nb -n $ns
+                              oc delete pvc $pvc -n $ns
+                          fi
                       else
-                          echo "Skipping $nb: user $user does not belong to any monitored group."
+                          echo "user $user does not belong to $GROUP_NAME_1 or $GROUP_NAME_2, deleting the notebook"
+                          oc delete notebook $nb -n $ns
+                          oc delete pvc $pvc -n $ns
                       fi
                   done <<< "$notebooks"
               env:
               # EDIT VALUE HERE BEFORE RUNNING
               - name: GROUP_NAME_1
-                value: <group_1>
+                value: "cs210"
               # EDIT VALUE HERE BEFORE RUNNING
               - name: GROUP_NAME_2
-                value: <group_2>
+                value: "ds210"
               # EDIT VALUE HERE BEFORE RUNNING
               - name: CUTOFF_TIME_1
-                value: "21600"
-              # EDIT VALUE HERE BEFORE RUNNING
-              - name: CUTOFF_TIME_2
                 value: "43200"
               # EDIT VALUE HERE BEFORE RUNNING
-              - name: IMAGE_NAME
-                value: "ucsls-nerc-rhoai"
+              - name: IMAGE_NAME_1
+                value: "ucsls-f24"
+              - name: IMAGE_NAME_2
+                value: "jupyter-rust"
+              - name: IMAGE_NAME_3
+                value: "vscode-rust"
               resources:
                 limits:
+                  cpu: 100m
                   memory: 800Mi
                 requests:
+                  cpu: 100m
                   memory: 400Mi
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File

--- a/cronjobs/nb-culler/kustomization.yaml
+++ b/cronjobs/nb-culler/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
   - cronjob.yaml
   - rolebinding.yaml
   - serviceaccount.yaml
-namespace: ope-rhods-testing-1fef2f
+namespace: rhods-notebooks


### PR DESCRIPTION
Update: 
cs210 and ds210 will be using this cronjob to monitor their notebooks resources. Here is the policy:
1. cs210: notebook max live time 12 hours, image `ucsls-f24`, image size: X Small
2. ds210: no notebook shutdown time, image `jupyter-rust` and `vscode-rust`, image size: Small
3. if user doesn't belong to cs210 or ds210, delete the notebook and pvc