### PR TITLE
Fix group sync user remove bug

### DIFF
--- a/container-images/group-sync/group-sync.py
+++ b/container-images/group-sync/group-sync.py
@@ -21,7 +21,12 @@ def add_users_to_group(group):
     group_name = group.model.metadata.name
     LOG.info('adding to group %s: %s', group_name, users_to_add)
     LOG.info('removing from group %s: %s', group_name, users_to_remove)
+    # Update the group's users list
     group.patch({'users': list(users_in_rolebinding)})
+    # Remove users from the group
+    for user in users_to_remove:
+        group.model.users.remove(user)
+    group.patch({'users': list(group.model.users)})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR resolves a known bug in group-sync cronjob:  when class users are added to `edit` role in openshift, the cronjob works fine to add them to the class group. But when removing users from the `edit` role, the cronjob doesn't remove the user from the group.