### PR TITLE
gpu-class: use nerc-node-reader clusterrole

### DIFF
--- a/gpu-class/gpu-class-setup.sh
+++ b/gpu-class/gpu-class-setup.sh
@@ -72,7 +72,7 @@ add_sa_to_clusterrolebinding() {
     notebook_name=$2
 
     oc adm policy add-cluster-role-to-user pod-reader --rolebinding-name="csw-pod-reader" system:serviceaccount:$namespace:$notebook_name --as system:admin
-    oc adm policy add-cluster-role-to-user node-reader --rolebinding-name="csw-node-reader" system:serviceaccount:$namespace:$notebook_name --as system:admin
+    oc adm policy add-cluster-role-to-user nerc-node-reader --rolebinding-name="csw-node-reader" system:serviceaccount:$namespace:$notebook_name --as system:admin
     oc adm policy add-cluster-role-to-user kueue-clusterqueue-reader --rolebinding-name="csw-kueue-clusterqueue-reader" system:serviceaccount:$namespace:$notebook_name --as system:admin
 }
 


### PR DESCRIPTION
This clusterrole already exists and is equivalent to the previous node-reader clusterrole defined for the course.

See OCP-on-NERC/nerc-ocp-config#781