### PR TITLE
Add class cs599 nb-culler and update group-sync image

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This offers us a way to keep class users added to course namespaces via ColdFron
     oc project <namespace>
 ```
 
-3. Update the `GROUP_NAME` and `NAMESPACE` env variables in cronjobs/group-sync/cronjob.yaml
+3. Update the `GROUP_NAME` and `NAMESPACE` env variables in cronjobs/group-sync/cronjob.yaml and update `namespace` variable in kustomization.yaml
 4. From cronjobs/group-sync/ directory run:
 ```
     oc apply -k . --as system:admin
@@ -33,7 +33,7 @@ Alternatively, to run the script immediately:
 
 3. Run:
 ```
-    kubectl create -n rhods-notebooks job --from=cronjob/group-sync group-sync
+    kubectl create -n <class_namespace> job --from=cronjob/group-sync group-sync
 ```
 
 ### nb-culler

--- a/container-images/group-sync/Dockerfile
+++ b/container-images/group-sync/Dockerfile
@@ -3,9 +3,12 @@ FROM quay.io/operate-first/opf-toolbox:v0.8.0
 # Create the destination directory
 WORKDIR /scripts
 
+# Install pip first
+RUN dnf install -y python3-pip
+
 # Install requirements first to maximize caching
-COPY src/python/group-sync/requirements.txt ./requirements.txt
-RUN pip install -r requirements.txt
+COPY requirements.txt ./requirements.txt
+RUN pip3 install -r requirements.txt
 
 # Install the group-sync application
-COPY src/python/group-sync/group-sync.py ./
+COPY group-sync.py ./

--- a/container-images/group-sync/group-sync.py
+++ b/container-images/group-sync/group-sync.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import openshift as oc
+import openshift_client as oc
 import logging
 
 LOG = logging.getLogger(__name__)
@@ -13,7 +13,8 @@ def add_users_to_group(group):
     users_in_rolebinding = set(
         subject['name'] for subject in rolebinding.model.subjects
     )
-    users_in_group = set(group.model.users)
+    # Handle case where group.model.users might be None
+    users_in_group = set(group.model.users) if group.model.users else set()
 
     users_to_add = users_in_rolebinding.difference(users_in_group)
     users_to_remove = users_in_group.difference(users_in_rolebinding)

--- a/cronjobs/group-sync/cronjob.yaml
+++ b/cronjobs/group-sync/cronjob.yaml
@@ -13,15 +13,15 @@ spec:
           serviceAccountName: group-sync
           containers:
           - name: group-sync
-            image: ghcr.io/ocp-on-nerc/bu-rhoai:toolkit
-            command: ["python", "group-sync.py"]
+            image: quay.io/sdanni/bu-rhoai:toolkit
+            command: ["python3", "group-sync.py"]
             env:
             # EDIT VALUE HERE BEFORE RUNNING
             - name: GROUP_NAME
-              value: <group>
+              value: cs210
             # EDIT VALUE HERE BEFORE RUNNING
             - name: NAMESPACE
-              value: <namespace>
+              value: cs210-f25-ab47f6
             imagePullPolicy: Always
           restartPolicy: Never
   successfulJobsHistoryLimit: 7

--- a/cronjobs/group-sync/kustomization.yaml
+++ b/cronjobs/group-sync/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
   - rolebinding.yaml
   - serviceaccount.yaml
 # EDIT VALUE HERE BEFORE APPLYING
-namespace: <namespace>
+namespace: cs210-f25-ab47f6

--- a/cronjobs/nb-culler/clusterrole.yaml
+++ b/cronjobs/nb-culler/clusterrole.yaml
@@ -38,3 +38,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch

--- a/cronjobs/nb-culler/kustomization.yaml
+++ b/cronjobs/nb-culler/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
   - cronjob.yaml
   - rolebinding.yaml
   - serviceaccount.yaml
-namespace: rhods-notebooks
+namespace: ope-rhods-testing

--- a/gpu-class/gpu-class-setup.sh
+++ b/gpu-class/gpu-class-setup.sh
@@ -79,7 +79,7 @@ add_sa_to_clusterrolebinding() {
 # create_clusterrole_bindings
 
 oc get ns | grep "^${CLASS_NAME}-" | awk '{print $1}' | while read ns; do
-    # ns="bu-cs599-pmpp-cuda-71cd48"
+    #ns="ja-ope-test"
     oc project "$ns"
 
     #create a workbench and save the name of the notebook to apply rolebindings


### PR DESCRIPTION
The current group sync container image is broken. Updated the image and pushed to quay.io registry.
The group sync and nb-culler cronjobs have been successfully running on edu cluster